### PR TITLE
Correct vertical Timings

### DIFF
--- a/cores/mist/viking.v
+++ b/cores/mist/viking.v
@@ -66,9 +66,9 @@ localparam HBP2 = 192;
 
 // x1024
 localparam V    = 1024;
-localparam VFP  = 9;
-localparam VS   = 4;
-localparam VBP  = 9;
+localparam VFP  = 1;
+localparam VS   = 3;
+localparam VBP  = 38;
 
 assign read = (bus_cycle == 2) && me;  // memory enable can directly be used as a ram read signal
 


### PR DESCRIPTION
Fixes an issue that the outputted mode is detected as 1600x1000 by my monitor. I get stable 1280x1024 with these timings, may help someone else.